### PR TITLE
Add brotherbother to master + py3 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 python:
     - "2.7"
-install: "pip install -r requirements.txt"
+install:
+    - "pip install requests"
+    - "pip install -r requirements.txt"
 script: "pylint --errors-only tombot"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
--e git://github.com/tgalal/yowsup.git#egg=yowsupgit
--e git+https://github.com/spasticVerbalizer/fortune.git#egg=fortunegit
-https://github.com/shantanoo/python-duckduckgo/archive/master.zip
 requests==2.9.1
 wolframalpha==1.2
 pushbullet-cli==0.7.1
 pylint==1.5.3
 configobj==5.0.6
+-e git://github.com/tgalal/yowsup.git#egg=yowsupgit
+-e git+https://github.com/spasticVerbalizer/fortune.git#egg=fortunegit
+https://github.com/shantanoo/python-duckduckgo/archive/master.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 -e git://github.com/tgalal/yowsup.git#egg=yowsupgit
 -e git+https://github.com/spasticVerbalizer/fortune.git#egg=fortunegit
-duckduckgo2==0.242
+https://github.com/shantanoo/python-duckduckgo/archive/master.zip
+requests
 wolframalpha==1.2
 pushbullet-cli==0.7.1
 pylint==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 -e git://github.com/tgalal/yowsup.git#egg=yowsupgit
 -e git+https://github.com/spasticVerbalizer/fortune.git#egg=fortunegit
 https://github.com/shantanoo/python-duckduckgo/archive/master.zip
-requests
+requests==2.9.1
 wolframalpha==1.2
 pushbullet-cli==0.7.1
 pylint==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pylint==1.5.3
 configobj==5.0.6
 -e git://github.com/tgalal/yowsup.git#egg=yowsupgit
 -e git+https://github.com/spasticVerbalizer/fortune.git#egg=fortunegit
-https://github.com/shantanoo/python-duckduckgo/archive/master.zip
+-e git+https://github.com/shantanoo/python-duckduckgo.git#egg=python-duckduckgo

--- a/tombot/helper_functions.py
+++ b/tombot/helper_functions.py
@@ -59,7 +59,7 @@ DICE_PATTERN = re.compile(DICE_REGEX, re.IGNORECASE)
 DICE_MODIFIER_OPERATORS = {
     '+': operator.add,
     '-': operator.sub,
-    '/': operator.div,
+    '/': operator.truediv,
     '*': operator.mul,
     'x': operator.mul,
     '%': operator.mod,

--- a/tombot/layer.py
+++ b/tombot/layer.py
@@ -527,12 +527,14 @@ class TomBotLayer(YowInterfaceLayer):
                 'SELECT id,jid,lastactive,primary_nick FROM users WHERE id = ?',
                 (cmd,))
         else:
-            self.cursor.execute(
-                'SELECT id,jid,lastactive,primary_nick FROM users WHERE primary_nick LIKE ?',
-                (cmd,))
-        result = self.cursor.fetchone()
-        if result is None:
-            return 'Ken ik niet'
+            try:
+                userjid = self.nick_to_jid(cmd)
+                self.cursor.execute(
+                    'SELECT id,jid,lastactive,primary_nick FROM users WHERE jid = ?',
+                    (userjid,))
+                result = self.cursor.fetchone()
+            except KeyError:
+                return 'Ken ik niet'
         reply = 'Nicks for {} ({}/{}):\n'.format(result[3], result[1], result[0])
         self.cursor.execute('SELECT name FROM nicks WHERE jid = ?',
                             (result[1],))

--- a/tombot/layer.py
+++ b/tombot/layer.py
@@ -123,16 +123,21 @@ class TomBotLayer(YowInterfaceLayer):
 
             # Who sent the message?
             senderjid = determine_sender(message)
+            logging.debug('Resolving sender %s', senderjid)
             try:
                 sendername = self.jid_to_nick(senderjid)
+                logging.debug('Sendernick %s', sendername)
             except KeyError:
                 sendername = senderjid
+                logging.debug('Could not find jid %s', senderjid)
 
             # Who was mentioned?
             try:
                 targetjid = self.nick_to_jid(nick)
-            except KeyError:
+            except KeyError as e:
                 # Some nick that is unknown, pass
+                logging.debug('Could not resolve nick %s', nick)
+                logging.debug('Exception %s', e)
                 continue
 
             if targetjid not in mentioned_sent:
@@ -595,8 +600,8 @@ class TomBotLayer(YowInterfaceLayer):
         '''
         # Search authornames first
         queries = [
-            'SELECT jid FROM users WHERE primary_nick = ?',
-            'SELECT jid FROM nicks WHERE name = ?',
+            'SELECT jid FROM users WHERE primary_nick LIKE ?',
+            'SELECT jid FROM nicks WHERE name LIKE ?',
             ]
         for query in queries:
             self.cursor.execute(query, (name,))


### PR DESCRIPTION
- Adds the anonsend/bother command
- Switches diceroll div to truediv (which it should have been all along)
- Robusterizes nick/jid resolution by using separate functions
- Switches duckduckgo to a py3 compatible fork
(adds new dependency on requests, which has to be installed before installing duckduckgo)